### PR TITLE
Import path switch

### DIFF
--- a/src/main/transform.ml
+++ b/src/main/transform.ml
@@ -25,7 +25,7 @@ let expand_file filename =
     prerr_endline ("Syntax error in \"" ^ filename ^ "\": " ^ msg) ;
     prerr_endline ("Line " ^ (string_of_int pos.pos_lnum) ^ " at character " ^ (string_of_int (pos.pos_cnum - pos.pos_bol))) in
 
-  let rec expand_imports processed_imports globals fns exts = function
+  let rec expand_imports processed_imports globals fns exts dir = function
       [] -> ([], globals, fns, exts)
     | import :: imports ->
       (* print_endline "--------";
@@ -40,6 +40,7 @@ let expand_file filename =
           Parsing.Parse_error -> print_error_location import "" lexbuf ; exit(-1)
         | Scanner.SyntaxError(s) -> print_error_location import s lexbuf ; exit(-1)
       in
+      let file_imports = List.map (fun file -> dir ^ "/" ^ file) file_imports in
       let new_proc = StringSet.add import processed_imports and _ = close_in in_chan in
       (* print_endline ("Now I'm done with: ") ; *)
       (* StringSet.iter (fun a -> print_endline a) new_proc; *)
@@ -47,8 +48,8 @@ let expand_file filename =
       let new_imports = StringSet.elements (StringSet.of_list (List.filter first_im_hearing_about file_imports)) in
       (* print_endline ("First I'm hearing about:") ; *)
       (* List.iter print_endline new_imports; *)
-      expand_imports new_proc (globals @ file_globals) (fns @ file_functions) (exts @ file_externs) (imports @ new_imports) in
-  expand_imports StringSet.empty [] [] [] [filename]
+      expand_imports new_proc (globals @ file_globals) (fns @ file_functions) (exts @ file_externs) (Filename.dirname import) (imports @ new_imports) in
+  expand_imports StringSet.empty [] [] [] (Filename.dirname filename) [filename]
 
 let expand_expressions (imports, globals, functions, externs) =
   let lit_zero = LitInt(0) in let abs_zero = Abs(lit_zero) in

--- a/testcases/inputs/test_calling_func_from_import.xtnd
+++ b/testcases/inputs/test_calling_func_from_import.xtnd
@@ -1,4 +1,4 @@
-import "samples/gcd_func.xtnd";
+import "../../samples/gcd_func.xtnd";
 
 main([1,n] args){
   return printf(1,toString( gcd(70, 55))+"\n") -> 0;

--- a/testcases/inputs/test_globals_between_imports.xtnd
+++ b/testcases/inputs/test_globals_between_imports.xtnd
@@ -1,4 +1,4 @@
-import "testcases/assets/string.xtnd";
+import "../../testcases/assets/string.xtnd";
 global foo;
 global [2, 5] bar;
-import "testcases/assets/string.xtnd";
+import "../../testcases/assets/string.xtnd";

--- a/testcases/inputs/test_multiple_imports.xtnd
+++ b/testcases/inputs/test_multiple_imports.xtnd
@@ -1,2 +1,2 @@
-import "testcases/assets/string.xtnd";
-import "testcases/assets/string.xtnd";
+import "../../testcases/assets/string.xtnd";
+import "../../testcases/assets/string.xtnd";

--- a/testcases/inputs/test_single_import.xtnd
+++ b/testcases/inputs/test_single_import.xtnd
@@ -1,4 +1,4 @@
-import "samples/gcd_func.xtnd";
+import "../../samples/gcd_func.xtnd";
 
 main([1,n] args) {
   return printf(1, toString(gcd(70, 55)) + "\n") -> 0;


### PR DESCRIPTION
Our import style for extend files was relative path from the root directory. However it makes more sense to use relative imports for our project.
Java uses paths from the root directory, since it is linking a lot of extern libraries and it has solid frameworks supporting it. Javascript / ES 6 imports use relative paths. This method might seem a little hacky, but it is definitely better for us, since users want to import individual libraries that they need. #25 