### PR TITLE
Subrange string

### DIFF
--- a/src/stdlib/lib.c
+++ b/src/stdlib/lib.c
@@ -52,6 +52,46 @@ value_p extend_to_string(value_p val) {
  			setString(_new, "empty", 5);
  			return _new;
  		}
+		else if(val->flags == FLAG_SUBRANGE) {
+			int i,j,len;
+			value_p value;
+			char *result, *res;
+			len = 0;
+			subrange_p sr = val->subrange;
+			value_p *strs = malloc(sizeof(value_p) * sr->subrange_num_cols * sr->subrange_num_rows);
+			for(i = 0; i < sr->subrange_num_rows; i++) {
+				for(j = 0; j < sr->subrange_num_cols; j++) {
+					value = extend_to_string(getValSR(sr, i, j));
+					//debug_print(value, "");
+					strs[i * sr->subrange_num_cols + j] = value;
+					len += value->str->length;
+				}
+			}
+			len += sr->subrange_num_rows * sr->subrange_num_cols + 1 /*closing paren*/;
+			res = result = malloc(len + 1/*terminal character*/);
+			*result = '{';
+			result++;
+			for(i = 0; i < sr->subrange_num_rows; i++) {
+				for(j = 0; j < sr->subrange_num_cols; j++) {
+					memcpy(result,strs[i * sr->subrange_num_cols + j]->str->text, strs[i * sr->subrange_num_cols + j]->str->length);
+					result += strs[i * sr->subrange_num_cols + j]->str->length;
+					if(j != sr->subrange_num_cols - 1) {
+						*result = ',';
+						result++;
+					}
+				}
+				if(i != sr->subrange_num_rows - 1) {
+					*result = ';';
+					result++;
+				}
+			}
+			*result = '}';
+			value_p ret_val = new_val();
+			setString(ret_val, res, len);
+			return ret_val;
+		} else {
+			__builtin_unreachable();
+		}
 		// If the struct does not hold a string or number, return empty?
 		return new_val();
 }

--- a/src/stdlib/runtime.c
+++ b/src/stdlib/runtime.c
@@ -429,6 +429,13 @@ value_p deref_subrange_p(subrange_p subrng) {
 	}
 }
 
+value_p getValSR(struct subrange_t *sr, int r, int c) {
+	if(sr->base_var_offset_row + sr->subrange_num_rows <= r
+		|| sr->base_var_offset_col + sr->subrange_num_cols <= c)
+		return new_val();
+	return getVal(sr->range, r + sr->base_var_offset_row, c + sr->base_var_offset_col);
+}
+
 value_p getVal(struct var_instance *inst, int r, int c) {
 	/* If we're going to return new_val() then we have to
 	 * do clone_value(). Otherwise the receiver won't know

--- a/src/stdlib/runtime.h
+++ b/src/stdlib/runtime.h
@@ -155,4 +155,5 @@ value_p clone_value(value_p old_value);
 void delete_string_p(string_p old_string);
 void delete_subrange_p(subrange_p old_subrange);
 void delete_value(value_p old_value);
+value_p getValSR(struct subrange_t *sr, int r, int c);
 value_p getVal(struct var_instance *inst, int x, int y);

--- a/tc.xtnd
+++ b/tc.xtnd
@@ -1,8 +1,8 @@
 main(args){
   [5,5]foo;
-  [1,1] x := 2;
-  foo[1:4,1:x] = 1 + 1 + 1;
+  [1,1] x := 3;
+  foo[1:5,1:x] = 1 + 1 + 1;
   foo[0,0] = 3 + 2;
   foo[1:,0] = 67 - 42;
-  return foo[0,0] -> 0;
+  return print(1,to_string(foo) + "\n") -> 0;
 }


### PR DESCRIPTION
This method is in the C stdlib and allows to print a subrange as string.
It does not escape strings and it should be written in Extend, but it provides a first usable version.