### PR TITLE
Move all initializations into their own function; only box strings once

### DIFF
--- a/src/main/codegen.ml
+++ b/src/main/codegen.ml
@@ -479,11 +479,11 @@ let translate (globals, functions, externs) =
           let val_p_list_list = List.map (fun x -> List.map get_val_p x) rl in
           let cellnums = zero_until (num_rows * num_cols) in
           let build_empty x =
-            let emptyval = Llvm.build_malloc base_types.value_p ("" ^ (string_of_int x)) literal_bod in
+            let emptyval = Llvm.build_malloc base_types.value_t ("" ^ (string_of_int x)) literal_bod in
             let _ = store_empty emptyval literal_bod in
             let emptydst = Llvm.build_in_bounds_gep vals_array [|Llvm.const_int base_types.int_t x|] "" literal_bod in
             let _ = Llvm.build_store emptyval emptydst literal_bod in
-            let statusdst = Llvm.build_in_bounds_gep vals_array [|Llvm.const_int base_types.int_t x|] "" literal_bod in
+            let statusdst = Llvm.build_in_bounds_gep status_array [|Llvm.const_int base_types.int_t x|] "" literal_bod in
             let _ = Llvm.build_store (Llvm.const_int base_types.char_t (var_instance_status_flags_index Calculated)) statusdst literal_bod in
             () in
           List.iter build_empty cellnums ;
@@ -496,6 +496,7 @@ let translate (globals, functions, externs) =
 
           let local_val_p = Llvm.build_load global_val_p_p "local_value_p" old_builder in
           let ret_val = Llvm.build_call (Hashtbl.find runtime_functions "clone_value") [|local_val_p|] "ret_val" old_builder in
+          let _ = Llvm.build_call (Hashtbl.find runtime_functions "debug_print") [|ret_val; Llvm.const_pointer_null base_types.char_p|] "" old_builder in
           (ret_val, old_builder)
       | Call(fn,exl) -> (*TODO: Call needs to be reviewed. Possibly switch call arguments to value_p*)
         let build_one_expr (arg_list, intermediate_builder) e =

--- a/tc.xtnd
+++ b/tc.xtnd
@@ -1,4 +1,4 @@
 main(args) {
-  foo := printv(1,"Hello World\n") -> printv(1,"Hello again\n") -> printv(1,"goodbye World\n") -> 0;
-  return foo;
+  foo := {"Hello, world", "Goodbye, world"};
+  return debug(foo) -> print_endline(foo[0]);
 }

--- a/tc.xtnd
+++ b/tc.xtnd
@@ -1,29 +1,4 @@
-main(args){
-  [5,5]foo;
-  [1,1] x := 3;
-  foo[1:5,1:x] = 1 + 1 + 1;
-  foo[0,0] = 3 + 2;
-  foo[1:,0] = 67 - 42;
-  [5,5] bar := #foo + 1;
-  return
-    write(STDOUT,to_string(foo[0,0])+"\n") ->
-    write(STDOUT,to_string(foo[0,0:2])+"\n") ->
-    write(STDOUT,to_string(foo[0:1,1])+"\n") ->
-    write(STDOUT,to_string(foo[,])+"\n") ->
-    write(STDOUT,to_string(foo[x,x])+"\n") ->
-    write(STDOUT,to_string(#foo)+"\n") ->
-    write(STDOUT,to_string(foo[4,])+"\n") ->
-    write(STDOUT,to_string(foo[2,1])+"\n") ->
-    write(STDOUT,to_string(foo)+"\n") ->
-    write(STDOUT,"\n") ->
-    write(STDOUT,to_string(bar[0,0])+"\n") ->
-    write(STDOUT,to_string(bar[0,0:2])+"\n") ->
-    write(STDOUT,to_string(bar[0:1,1])+"\n") ->
-    write(STDOUT,to_string(bar[,])+"\n") ->
-    write(STDOUT,to_string(bar[x,x])+"\n") ->
-    write(STDOUT,to_string(#bar)+"\n") ->
-    write(STDOUT,to_string(bar[4,])+"\n") ->
-    write(STDOUT,to_string(bar[2,1])+"\n") ->
-    write(STDOUT,to_string(bar)+"\n") ->
-    0;
+main(args) {
+  foo := printv(1,"Hello World\n") -> printv(1,"Hello again\n") -> printv(1,"goodbye World\n") -> 0;
+  return foo;
 }


### PR DESCRIPTION
OK, I have a plan at least for range literals.

I moved all the initialization stuff into its own (void) function (of no arguments) instead of doing it all in main(). main() just calls that function - it just makes it clear how the program is executing.

It's now boxing string literals only once, as part of the initialization. When an actual formula function executes, it just makes a shallow copy of the value_p that's hanging around in global address space.

I'll do the same thing with range literals. 